### PR TITLE
fix(rosetta-build): rustfmt feature logic

### DIFF
--- a/rosetta-build/src/builder.rs
+++ b/rosetta-build/src/builder.rs
@@ -175,9 +175,8 @@ impl RosettaConfig {
         let mut file = File::create(&output)?;
         file.write_all(generated.to_string().as_bytes())?;
 
-        if cfg!(feature = "rustfmt") {
-            rustfmt(&output)?;
-        }
+        #[cfg(feature = "rustfmt")]
+        rustfmt(&output)?;
 
         Ok(())
     }


### PR DESCRIPTION
*Actually* fixes https://github.com/LemmyNet/lemmy/issues/3000

When `rustfmt` is not available so we disable the `rustfmt` feature (`default-features=false`), we need to make sure we aren't actually still invoking the function.

Currently if this is done, the following results when building:
```
error[E0423]: expected function, found tool module `rustfmt`
   --> /host/cargo/registry/src/index.crates.io-6f17d22bba15001f/rosetta-build-0.1.2/src/builder.rs:179:13
    |
179 |             rustfmt(&output)?;
    |             ^^^^^^^ not a function

For more information about this error, try `rustc --explain E0423`.
error: could not compile `rosetta-build` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```

~~My solution was to just make the function a dummy function that will only attempt to invoke `rustfmt` if the feature is enabled.~~