### PR TITLE
fix(rosetta-build): allow all clippy lints

### DIFF
--- a/rosetta-build/src/gen.rs
+++ b/rosetta-build/src/gen.rs
@@ -91,7 +91,7 @@ impl<'a> CodeGenerator<'a> {
             .map(|(language, value)| self.match_arm_simple(language, value));
 
         quote! {
-            #[allow(clippy::match_single_binding)]
+            #[allow(clippy::all)]
             pub fn #name(&self) -> &'static str {
                 match self {
                     #(#arms,)*
@@ -128,7 +128,7 @@ impl<'a> CodeGenerator<'a> {
         let fallback = self.format_formatted(&data.fallback, &data.parameters);
 
         quote! {
-            #[allow(clippy::match_single_binding)]
+            #[allow(clippy::all)]
             pub fn #name(&self, #(#params),*) -> ::std::string::String {
                 match self {
                     #(#arms,)*


### PR DESCRIPTION
Ignore all clippy warnings/errors by adding `#[allow(clippy:all)]` to generated functions. Fixes #9.